### PR TITLE
GitHub linguist fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+mvnw* linguist-vendored

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 Stackable interceptors for PrintStream with copy, redirect, filter and passthrough.
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/6632b060ed324863a242a86c79217f02)](https://www.codacy.com/app/kemitix/print-stream-interceptor?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=kemitix/print-stream-interceptor&amp;utm_campaign=Badge_Grade)
-[![Coverage Status](https://coveralls.io/repos/github/kemitix/print-stream-interceptor/badge.svg?branch=master)](https://coveralls.io/github/kemitix/print-stream-interceptor?branch=master)
-[![codecov](https://codecov.io/gh/kemitix/print-stream-interceptor/branch/master/graph/badge.svg)](https://codecov.io/gh/kemitix/print-stream-interceptor)
-
-## Usage
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/50dcbe2b48824c6f92cad099195d8858)](https://www.codacy.com/app/kemitix/wrapper?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=kemitix/wrapper&amp;utm_campaign=Badge_Grade)
+[![Coverage Status](https://coveralls.io/repos/github/kemitix/wrapper/badge.svg?branch=master)](https://coveralls.io/github/kemitix/wrapper?branch=master)
+[![codecov](https://codecov.io/gh/kemitix/wrapper/branch/master/graph/badge.svg)](https://codecov.io/gh/kemitix/wrapper)
 


### PR DESCRIPTION
Github sees the `mvnw` and `mvnw.cmd` files thinks the project language is a shell rather than Java.