### PR TITLE
.gitattributes: mark maven wrapper scripts as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+mvnw* linguist-vendored


### PR DESCRIPTION
Github sees the `mvnw` and `mvnw.cmd` files and thinks the project language is shell rather than Java.
