### PR TITLE
Implement basic wrapper by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ Stackable interceptors for PrintStream with copy, redirect, filter and passthrou
 [![Coverage Status](https://coveralls.io/repos/github/kemitix/wrapper/badge.svg?branch=master)](https://coveralls.io/github/kemitix/wrapper?branch=master)
 [![codecov](https://codecov.io/gh/kemitix/wrapper/branch/master/graph/badge.svg)](https://codecov.io/gh/kemitix/wrapper)
 
+## Notes
+
+* Implementations of `Wrapper` do not need to implement the basic `Wrapper` methods. They only need to now implement the `WrapperState<T> getWrapperState()` method.
+* Implementations of `Wrapper<T>` must  `extend` or `implement` the Wrapper's Generic type `T`.
+* Implementations of `Wrapper<T>` must not override the default methods implemented in `Wrapper`.

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,11 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <junit.version>4.12</junit.version>
+        <assertj.version>3.8.0</assertj.version>
+        <mockito.version>2.8.47</mockito.version>
+    </properties>
     <parent>
         <groupId>net.kemitix</groupId>
         <artifactId>kemitix-parent</artifactId>
@@ -12,5 +17,25 @@
     <version>0.2.0-SNAPSHOT</version>
     <name>Wrapper</name>
     <description>Wrapper for Generic types.</description>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/src/main/java/net/kemitix/wrapper/Wrapper.java
+++ b/src/main/java/net/kemitix/wrapper/Wrapper.java
@@ -21,10 +21,16 @@
 
 package net.kemitix.wrapper;
 
+import lombok.NonNull;
+
 import java.util.Optional;
 
 /**
  * Wrapper for Generic types.
+ *
+ * <p>N.B. all classes that implement this interface <strong>must</strong> also extend or implement {@code T}.</p>
+ *
+ * <p>N.B. all classes that implement this interface <strong>must not</strong> override the default methods.</p>
  *
  * @param <T> the type of object to wrap
  *
@@ -33,18 +39,29 @@ import java.util.Optional;
 public interface Wrapper<T> {
 
     /**
+     * Gets the Wrapper's state object.
+     *
+     * @return the WrapperState
+     */
+    WrapperState<T> getWrapperState();
+
+    /**
      * Fetch the core item being Wrapper.
      *
      * @return the core item
      */
-    T getCore();
+    default T getWrapperCore() {
+        return getWrapperState().getWrapperCore();
+    }
 
     /**
      * Gets the inner wrapper if one is present.
      *
      * @return An Optional containing the inner wrapper if present, otherwise is empty
      */
-    Optional<Wrapper<T>> findInnerWrapper();
+    default Optional<Wrapper<T>> findInnerWrapper() {
+        return getWrapperState().findInnerWrapper();
+    }
 
     /**
      * Remove the wrapper from the chain of wrappers.
@@ -53,12 +70,23 @@ public interface Wrapper<T> {
      *
      * @param wrapper the wrapper to remove
      */
-    void remove(Wrapper<T> wrapper);
+    default void removeWrapper(@NonNull Wrapper<T> wrapper) {
+        getWrapperState().removeWrapper(wrapper);
+    }
 
     /**
      * Provides the core item's own interface.
      *
      * @return the core item as a T object
      */
-    T asCore();
+    @SuppressWarnings("unchecked")
+    default T asCore() {
+        return (T) this;
+    }
+
+    default T getWrapperDelegate() {
+        return getWrapperState().findInnerWrapper()
+                                .map(Wrapper::asCore)
+                                .orElseGet(this::getWrapperCore);
+    }
 }

--- a/src/main/java/net/kemitix/wrapper/WrapperState.java
+++ b/src/main/java/net/kemitix/wrapper/WrapperState.java
@@ -1,0 +1,83 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Paul Campbell
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies
+ * or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.kemitix.wrapper;
+
+import lombok.Getter;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The state for {@link Wrapper} implementations.
+ *
+ * @param <T> the type of object to wrap
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ */
+public class WrapperState<T> implements Wrapper<T> {
+
+    @Getter
+    private final T wrapperCore;
+
+    private final AtomicReference<Wrapper<T>> innerWrapper = new AtomicReference<>();
+
+    /**
+     * Constructor for wrapping a {@link T} object.
+     *
+     * @param object the object to wrap
+     */
+    public WrapperState(final T object) {
+        this.wrapperCore = object;
+    }
+
+    /**
+     * Constructor for wrapping an already wrapped {@link T} object.
+     *
+     * @param wrapper the wrapped object
+     */
+    public WrapperState(final Wrapper<T> wrapper) {
+        this.innerWrapper.set(wrapper);
+        this.wrapperCore = wrapper.getWrapperCore();
+    }
+
+    @Override
+    public final WrapperState<T> getWrapperState() {
+        return this;
+    }
+
+    @Override
+    public final Optional<Wrapper<T>> findInnerWrapper() {
+        return Optional.ofNullable(innerWrapper.get());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final void removeWrapper(final Wrapper<T> wrapper) {
+        if (innerWrapper.compareAndSet(wrapper, null)) {
+            wrapper.findInnerWrapper()
+                   .ifPresent(innerWrapper::set);
+            return;
+        }
+        Optional.ofNullable(innerWrapper.get())
+                .ifPresent(wrapped -> wrapped.removeWrapper(wrapper));
+    }
+}

--- a/src/test/java/net/kemitix/wrapper/WrapperStateTest.java
+++ b/src/test/java/net/kemitix/wrapper/WrapperStateTest.java
@@ -1,0 +1,78 @@
+package net.kemitix.wrapper;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WrapperState}.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ */
+public class WrapperStateTest {
+
+    @Test
+    public void canCreateStateForAnObject() {
+        //given
+        final Object o = new Object();
+        //when
+        final WrapperState<Object> wrapperState = new WrapperState<>(o);
+        //then
+        assertThat(wrapperState.getWrapperCore()).isSameAs(o);
+        assertThat(wrapperState.getWrapperDelegate()).isSameAs(o);
+    }
+
+    @Test
+    public void canCreateStateForWrappedObject() {
+        //given
+        final Object o = new Object();
+        final WrapperState<Object> existingWrapperState = new WrapperState<>(o);
+        //when
+        final WrapperState<Object> wrapperState = new WrapperState<>(existingWrapperState);
+        //then
+        assertThat(wrapperState.getWrapperDelegate()).isSameAs(existingWrapperState);
+    }
+
+    @Test
+    public void whenOneInnerWrapperCanRemoveIt() {
+        //given
+        final Object o = new Object();
+        final WrapperState<Object> first = new WrapperState<>(o);
+        final WrapperState<Object> second = new WrapperState<>(first);
+        //when
+        second.removeWrapper(first);
+        //then
+        assertThat(second.getWrapperDelegate()).isSameAs(o);
+    }
+
+    @Test
+    public void whenTwoInnerWrappersCanRemoveFirst() {
+        //given
+        final Object o = new Object();
+        final WrapperState<Object> first = new WrapperState<>(o);
+        final WrapperState<Object> second = new WrapperState<>(first);
+        final WrapperState<Object> third = new WrapperState<>(second);
+        //when
+        third.removeWrapper(first);
+        //then
+        assertThat(second.getWrapperDelegate()).isSameAs(o);// second now wraps o directly
+        assertThat(third.getWrapperDelegate()).isSameAs(second);// no change
+    }
+
+    @Test
+    public void whenTwoInnerWrappersCanRemoveSecond() {
+        //given
+        final Object o = new Object();
+        final WrapperState<Object> first = new WrapperState<>(o);
+        final WrapperState<Object> second = new WrapperState<>(first);
+        final WrapperState<Object> third = new WrapperState<>(second);
+        assertThat(first.getWrapperDelegate()).isSameAs(o);
+        assertThat(second.getWrapperDelegate()).isSameAs(first);
+        assertThat(third.getWrapperDelegate()).isSameAs(second);
+        //when
+        third.removeWrapper(second);
+        //then
+        assertThat(first.getWrapperDelegate()).isSameAs(o);// no change
+        assertThat(third.getWrapperDelegate()).isSameAs(first);// third now wraps first
+    }
+}

--- a/src/test/java/net/kemitix/wrapper/WrapperTest.java
+++ b/src/test/java/net/kemitix/wrapper/WrapperTest.java
@@ -1,0 +1,72 @@
+package net.kemitix.wrapper;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Tests for {@link Wrapper}.
+ *
+ * @author Paul Campbell (pcampbell@kemitix.net)
+ */
+public class WrapperTest {
+
+    private WrapperState<Object> wrapperState;
+
+    private Wrapper<Object> objectWrapper;
+
+    private Object o;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        o = new Object();
+        objectWrapper = () -> wrapperState;
+    }
+
+    @Test
+    public void canGetWrapperCoreFromState() {
+        //given
+        wrapperState = new WrapperState<>(o);
+        //when
+        final Object wrapperCore = objectWrapper.getWrapperCore();
+        //then
+        assertThat(wrapperCore).isSameAs(o);
+    }
+
+    @Test
+    public void canFindInnerWrapperInState() {
+        //given
+        final Wrapper<Object> inner = new WrapperState<>(o);
+        wrapperState = new WrapperState<>(inner);
+        //when
+        final Optional<Wrapper<Object>> innerWrapper = objectWrapper.findInnerWrapper();
+        //then
+        assertThat(innerWrapper).contains(inner);
+    }
+
+    @Test
+    public void canRemoveWrapperFromState() {
+        //given
+        final WrapperState<Object> innerWrapper = new WrapperState<>(o);
+        wrapperState = new WrapperState<>(innerWrapper);
+        //when
+        objectWrapper.removeWrapper(innerWrapper);
+        //then
+        assertThat(objectWrapper.getWrapperDelegate()).isSameAs(o);
+    }
+
+    @Test
+    public void requireAWrapperToBeRemoved() {
+        assertThatNullPointerException().isThrownBy(() -> objectWrapper.removeWrapper(null))
+                                        .withMessage("wrapper");
+    }
+}

--- a/src/test/java/net/kemitix/wrapper/WrapperTest.java
+++ b/src/test/java/net/kemitix/wrapper/WrapperTest.java
@@ -2,14 +2,11 @@ package net.kemitix.wrapper;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 /**


### PR DESCRIPTION
Implementations of `Wrapper` do not need to implement the basic `Wrapper` methods. They only need to now implement the `WrapperState<T> getWrapperState()` method.

Implementations of `Wrapper<T>` must  `extend` or `implement` the Wrapper's Generic type `T`.

Implementations of `Wrapper<T>` must not override the default methods implemented in `Wrapper`.