### PR TITLE
Improved remove wrapper

### DIFF
--- a/src/main/java/net/kemitix/wrapper/Wrapper.java
+++ b/src/main/java/net/kemitix/wrapper/Wrapper.java
@@ -71,8 +71,13 @@ public interface Wrapper<T> {
      * @return {@code this} Wrapper if {@code wrapper} is not {@code this}, otherwise the Wrapper Delegate, which may be
      * the Wrapper Core
      */
+    @SuppressWarnings("unchecked")
     default T removeWrapper(@NonNull Wrapper<T> wrapper) {
-        return getWrapperState().removeWrapper(wrapper);
+        if (wrapper == this) {
+            return getWrapperDelegate();
+        }
+        return Optional.ofNullable(getWrapperState().removeWrapper(wrapper))
+                       .orElse((T) this);
     }
 
     /**

--- a/src/main/java/net/kemitix/wrapper/Wrapper.java
+++ b/src/main/java/net/kemitix/wrapper/Wrapper.java
@@ -95,4 +95,20 @@ public interface Wrapper<T> {
                                 .map(Wrapper::asCore)
                                 .orElseGet(this::getWrapperCore);
     }
+
+    /**
+     * Checks if the item is a Wrapper, and returns it as one, inside an Optional, if it is, otherwise it returns empty.
+     *
+     * @param item The item to check
+     * @param <T>  The type of the item
+     *
+     * @return an Optional containing either the item as a Wrapper, or empty is item isn't a Wrapper
+     */
+    @SuppressWarnings("unchecked")
+    static <T> Optional<Wrapper<T>> asWrapper(@NonNull T item) {
+        if (item instanceof Wrapper) {
+            return Optional.of((Wrapper<T>) item);
+        }
+        return Optional.empty();
+    }
 }

--- a/src/main/java/net/kemitix/wrapper/Wrapper.java
+++ b/src/main/java/net/kemitix/wrapper/Wrapper.java
@@ -66,12 +66,13 @@ public interface Wrapper<T> {
     /**
      * Remove the wrapper from the chain of wrappers.
      *
-     * <p>Can't be <em>this</em> wrapper.</p>
-     *
      * @param wrapper the wrapper to remove
+     *
+     * @return {@code this} Wrapper if {@code wrapper} is not {@code this}, otherwise the Wrapper Delegate, which may be
+     * the Wrapper Core
      */
-    default void removeWrapper(@NonNull Wrapper<T> wrapper) {
-        getWrapperState().removeWrapper(wrapper);
+    default T removeWrapper(@NonNull Wrapper<T> wrapper) {
+        return getWrapperState().removeWrapper(wrapper);
     }
 
     /**

--- a/src/main/java/net/kemitix/wrapper/WrapperState.java
+++ b/src/main/java/net/kemitix/wrapper/WrapperState.java
@@ -71,13 +71,18 @@ public class WrapperState<T> implements Wrapper<T> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public final void removeWrapper(final Wrapper<T> wrapper) {
-        if (innerWrapper.compareAndSet(wrapper, null)) {
-            wrapper.findInnerWrapper()
-                   .ifPresent(innerWrapper::set);
-            return;
+    public final T removeWrapper(final Wrapper<T> wrapper) {
+        if (wrapper == this) {
+            return wrapper.getWrapperDelegate();
         }
-        Optional.ofNullable(innerWrapper.get())
-                .ifPresent(wrapped -> wrapped.removeWrapper(wrapper));
+        findInnerWrapper().ifPresent(inner -> {
+            final T newDelegate = inner.removeWrapper(wrapper);
+            if (newDelegate instanceof Wrapper) {
+                innerWrapper.set((Wrapper<T>) newDelegate);
+            } else {
+                innerWrapper.set(null);
+            }
+        });
+        return (T) this;
     }
 }

--- a/src/main/java/net/kemitix/wrapper/WrapperState.java
+++ b/src/main/java/net/kemitix/wrapper/WrapperState.java
@@ -69,12 +69,17 @@ public class WrapperState<T> implements Wrapper<T> {
         return Optional.ofNullable(innerWrapper.get());
     }
 
+    /**
+     * This implementation, used only by {@link Wrapper}, returns a {@code null} if there is no change in the outermost
+     * wrapper.
+     *
+     * @param wrapper the wrapper to remove
+     *
+     * @return the new outermost wrapper, or null
+     */
     @Override
     @SuppressWarnings("unchecked")
     public final T removeWrapper(final Wrapper<T> wrapper) {
-        if (wrapper == this) {
-            return wrapper.getWrapperDelegate();
-        }
         findInnerWrapper().ifPresent(inner -> {
             final T newDelegate = inner.removeWrapper(wrapper);
             if (newDelegate instanceof Wrapper) {
@@ -83,6 +88,6 @@ public class WrapperState<T> implements Wrapper<T> {
                 innerWrapper.set(null);
             }
         });
-        return (T) this;
+        return null;
     }
 }

--- a/src/test/java/net/kemitix/wrapper/WrapperStateTest.java
+++ b/src/test/java/net/kemitix/wrapper/WrapperStateTest.java
@@ -13,11 +13,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class WrapperStateTest {
 
     @Test
-    public void canCreateStateForAnObject() {
+    public void canCreateWrapperStateForObject() {
         //given
-        final Object o = new Object();
+        val o = createSubject();
         //when
-        final WrapperState<Object> wrapperState = new WrapperState<>(o);
+        val wrapperState = createWrapperState(o);
         //then
         assertThat(wrapperState.getWrapperCore()).isSameAs(o);
         assertThat(wrapperState.getWrapperDelegate()).isSameAs(o);
@@ -26,88 +26,27 @@ public class WrapperStateTest {
     @Test
     public void canCreateStateForWrappedObject() {
         //given
-        final Object o = new Object();
-        final WrapperState<Object> existingWrapperState = new WrapperState<>(o);
+        val o = createSubject();
+        val inner = createWrapperState(o);
         //when
-        final WrapperState<Object> wrapperState = new WrapperState<>(existingWrapperState);
+        val wrapperState = createWrapperState(inner);
         //then
-        assertThat(wrapperState.getWrapperDelegate()).isSameAs(existingWrapperState);
+        assertThat(wrapperState.getWrapperDelegate()).isSameAs(inner);
     }
 
-    @Test
-    public void whenSingleWrapperCanRemoveItself() {
-        //given
-        val o = new Object();
-        val wrapper = new WrapperState<>(o);
-        //when
-        val result = wrapper.removeWrapper(wrapper);
-        //then
-        assertThat(result).isSameAs(o);
+    private WrapperState<Subject> createWrapperState(final Subject o) {
+        return new WrapperState<>(o);
     }
 
-    @Test
-    public void whenWrapperToRemoveIsInvalidThenIgnoreAndReturnSelf() {
-        //given
-        val o = new Object();
-        val wrapper = new WrapperState<>(o);
-        //when
-        val result = ((Wrapper<Object>) wrapper.removeWrapper(new WrapperState<>(o)));
-        //then
-        assertThat(result).isSameAs(wrapper);
-        assertThat(result.getWrapperDelegate()).isSameAs(o);
+    private WrapperState<Subject> createWrapperState(final WrapperState<Subject> inner) {
+        return new WrapperState<>(inner);
     }
 
-    @Test
-    public void whenTwoWrappersCanRemoveInner() {
-        //given
-        val o = new Object();
-        val inner = new WrapperState<Object>(o);
-        val outer = new WrapperState<Object>(inner);
-        //when
-        val result = ((Wrapper<Object>) outer.removeWrapper(inner));
-        //then
-        assertThat(result).isSameAs(outer);
-        assertThat(result.getWrapperDelegate()).isSameAs(o);
+    private Subject createSubject() {
+        return new Subject();
     }
 
-    @Test
-    public void whenTwoInnerWrappersCanRemoveFirst() {
-        //given
-        val o = new Object();
-        val inner = new WrapperState<Object>(o);
-        val middle = new WrapperState<Object>(inner);
-        val outer = new WrapperState<Object>(middle);
-        //when
-        val result = (Wrapper<Object>) outer.removeWrapper(inner);
-        //then
-        assertThat(result).isSameAs(outer);
-        assertThat(outer.getWrapperDelegate()).isSameAs(middle);
-        assertThat(middle.getWrapperDelegate()).isSameAs(o);
-    }
+    private class Subject {
 
-    @Test
-    public void whenTwoInnerWrappersCanRemoveSecond() {
-        //given
-        final Object o = new Object();
-        val inner = new WrapperState<Object>(o);
-        val middle = new WrapperState<Object>(inner);
-        val outer = new WrapperState<Object>(middle);
-        //when
-        val result = (Wrapper<Object>) outer.removeWrapper(middle);
-        //then
-        assertThat(result).isSameAs(outer);
-        assertThat(result.getWrapperDelegate()).isSameAs(inner);
-        assertThat(inner.getWrapperDelegate()).isSameAs(o);
-    }
-
-    @Test
-    public void canRemoveOnlyWrapper() {
-        //given
-        val o = new Object();
-        val wrapper = new WrapperState<Object>(o);
-        //when
-        val result = wrapper.removeWrapper(wrapper);
-        //then
-        assertThat(result).isSameAs(o);
     }
 }

--- a/src/test/java/net/kemitix/wrapper/WrapperStateTest.java
+++ b/src/test/java/net/kemitix/wrapper/WrapperStateTest.java
@@ -1,5 +1,6 @@
 package net.kemitix.wrapper;
 
+import lombok.val;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,45 +35,79 @@ public class WrapperStateTest {
     }
 
     @Test
-    public void whenOneInnerWrapperCanRemoveIt() {
+    public void whenSingleWrapperCanRemoveItself() {
         //given
-        final Object o = new Object();
-        final WrapperState<Object> first = new WrapperState<>(o);
-        final WrapperState<Object> second = new WrapperState<>(first);
+        val o = new Object();
+        val wrapper = new WrapperState<>(o);
         //when
-        second.removeWrapper(first);
+        val result = wrapper.removeWrapper(wrapper);
         //then
-        assertThat(second.getWrapperDelegate()).isSameAs(o);
+        assertThat(result).isSameAs(o);
+    }
+
+    @Test
+    public void whenWrapperToRemoveIsInvalidThenIgnoreAndReturnSelf() {
+        //given
+        val o = new Object();
+        val wrapper = new WrapperState<>(o);
+        //when
+        val result = ((Wrapper<Object>) wrapper.removeWrapper(new WrapperState<>(o)));
+        //then
+        assertThat(result).isSameAs(wrapper);
+        assertThat(result.getWrapperDelegate()).isSameAs(o);
+    }
+
+    @Test
+    public void whenTwoWrappersCanRemoveInner() {
+        //given
+        val o = new Object();
+        val inner = new WrapperState<Object>(o);
+        val outer = new WrapperState<Object>(inner);
+        //when
+        val result = ((Wrapper<Object>) outer.removeWrapper(inner));
+        //then
+        assertThat(result).isSameAs(outer);
+        assertThat(result.getWrapperDelegate()).isSameAs(o);
     }
 
     @Test
     public void whenTwoInnerWrappersCanRemoveFirst() {
         //given
-        final Object o = new Object();
-        final WrapperState<Object> first = new WrapperState<>(o);
-        final WrapperState<Object> second = new WrapperState<>(first);
-        final WrapperState<Object> third = new WrapperState<>(second);
+        val o = new Object();
+        val inner = new WrapperState<Object>(o);
+        val middle = new WrapperState<Object>(inner);
+        val outer = new WrapperState<Object>(middle);
         //when
-        third.removeWrapper(first);
+        val result = (Wrapper<Object>) outer.removeWrapper(inner);
         //then
-        assertThat(second.getWrapperDelegate()).isSameAs(o);// second now wraps o directly
-        assertThat(third.getWrapperDelegate()).isSameAs(second);// no change
+        assertThat(result).isSameAs(outer);
+        assertThat(outer.getWrapperDelegate()).isSameAs(middle);
+        assertThat(middle.getWrapperDelegate()).isSameAs(o);
     }
 
     @Test
     public void whenTwoInnerWrappersCanRemoveSecond() {
         //given
         final Object o = new Object();
-        final WrapperState<Object> first = new WrapperState<>(o);
-        final WrapperState<Object> second = new WrapperState<>(first);
-        final WrapperState<Object> third = new WrapperState<>(second);
-        assertThat(first.getWrapperDelegate()).isSameAs(o);
-        assertThat(second.getWrapperDelegate()).isSameAs(first);
-        assertThat(third.getWrapperDelegate()).isSameAs(second);
+        val inner = new WrapperState<Object>(o);
+        val middle = new WrapperState<Object>(inner);
+        val outer = new WrapperState<Object>(middle);
         //when
-        third.removeWrapper(second);
+        val result = (Wrapper<Object>) outer.removeWrapper(middle);
         //then
-        assertThat(first.getWrapperDelegate()).isSameAs(o);// no change
-        assertThat(third.getWrapperDelegate()).isSameAs(first);// third now wraps first
+        assertThat(result).isSameAs(outer);
+        assertThat(result.getWrapperDelegate()).isSameAs(inner);
+        assertThat(inner.getWrapperDelegate()).isSameAs(o);
+    }
+
+    @Test
+    public void canRemoveOnlyWrapper() {
+        //given
+        val o = new Object();
+        val wrapper = new WrapperState<Object>(o);
+        //when
+        val result = wrapper.removeWrapper(wrapper);
+        //then
+        assertThat(result).isSameAs(o);
     }
 }

--- a/src/test/java/net/kemitix/wrapper/WrapperTest.java
+++ b/src/test/java/net/kemitix/wrapper/WrapperTest.java
@@ -51,18 +51,7 @@ public class WrapperTest {
     }
 
     @Test
-    public void canRemoveWrapperFromState() {
-        //given
-        final WrapperState<Object> innerWrapper = new WrapperState<>(o);
-        wrapperState = new WrapperState<>(innerWrapper);
-        //when
-        objectWrapper.removeWrapper(innerWrapper);
-        //then
-        assertThat(objectWrapper.getWrapperDelegate()).isSameAs(o);
-    }
-
-    @Test
-    public void requireAWrapperToBeRemoved() {
+    public void removeWrapperRequiresAWrapper() {
         assertThatNullPointerException().isThrownBy(() -> objectWrapper.removeWrapper(null))
                                         .withMessage("wrapper");
     }

--- a/src/test/java/net/kemitix/wrapper/WrapperTest.java
+++ b/src/test/java/net/kemitix/wrapper/WrapperTest.java
@@ -133,6 +133,34 @@ public class WrapperTest {
         assertThat(result).isSameAs(subject);
     }
 
+    @Test
+    public void whenItemIsReallyAWrapperThenCanGetItAsAWrapper() {
+        //given
+        val subject = createSubject();
+        val wrapper = createWrapper(subject);
+        val asSubject = (Subject) wrapper;
+        //when
+        val asWrapper = Wrapper.asWrapper(asSubject);
+        //then
+        assertThat(asWrapper).contains(wrapper);
+    }
+
+    @Test
+    public void whenItemIsNotReallyAWrapperThenDoNotGetItAsAWrapper() {
+        //given
+        val subject = createSubject();
+        //when
+        val asWrapper = Wrapper.asWrapper(subject);
+        //then
+        assertThat(asWrapper).isEmpty();
+    }
+
+    @Test
+    public void whenItemIsNullThenAsWrapperThrowsException() {
+        assertThatNullPointerException().isThrownBy(() -> Wrapper.asWrapper(null))
+                                        .withMessage("item");
+    }
+
     @SuppressWarnings("unchecked")
     private Wrapper<Subject> verifyIsAWrapper(final Subject subject) {
         assertThat(subject).isInstanceOf(Wrapper.class);

--- a/src/test/java/net/kemitix/wrapper/WrapperTest.java
+++ b/src/test/java/net/kemitix/wrapper/WrapperTest.java
@@ -1,13 +1,12 @@
 package net.kemitix.wrapper;
 
-import org.junit.Before;
+import lombok.val;
 import org.junit.Test;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * Tests for {@link Wrapper}.
@@ -16,43 +15,165 @@ import static org.mockito.MockitoAnnotations.initMocks;
  */
 public class WrapperTest {
 
-    private WrapperState<Object> wrapperState;
-
-    private Wrapper<Object> objectWrapper;
-
-    private Object o;
-
-    @Before
-    public void setUp() {
-        initMocks(this);
-        o = new Object();
-        objectWrapper = () -> wrapperState;
-    }
-
     @Test
-    public void canGetWrapperCoreFromState() {
+    public void canGetWrapperCore() {
         //given
-        wrapperState = new WrapperState<>(o);
+        val subject = createSubject();
+        val wrapper = createWrapper(subject);
         //when
-        final Object wrapperCore = objectWrapper.getWrapperCore();
+        final Subject wrapperCore = wrapper.getWrapperCore();
         //then
-        assertThat(wrapperCore).isSameAs(o);
+        assertThat(wrapperCore).isSameAs(subject);
     }
 
     @Test
     public void canFindInnerWrapperInState() {
         //given
-        final Wrapper<Object> inner = new WrapperState<>(o);
-        wrapperState = new WrapperState<>(inner);
+        val subject = createSubject();
+        val inner = createWrapper(subject);
+        val outer = createWrapper(inner);
         //when
-        final Optional<Wrapper<Object>> innerWrapper = objectWrapper.findInnerWrapper();
+        final Optional<Wrapper<Subject>> innerWrapper = outer.findInnerWrapper();
         //then
         assertThat(innerWrapper).contains(inner);
     }
 
     @Test
     public void removeWrapperRequiresAWrapper() {
-        assertThatNullPointerException().isThrownBy(() -> objectWrapper.removeWrapper(null))
+        //given
+        val subject = createSubject();
+        val wrapper = createWrapper(subject);
+        //then
+        assertThatNullPointerException().isThrownBy(() ->
+                                                            //when
+                                                            wrapper.removeWrapper(null))
+                                        //and
                                         .withMessage("wrapper");
+    }
+
+    @Test
+    public void whenSingleWrapperCanRemoveItself() {
+        //given
+        val subject = createSubject();
+        val wrapper = createWrapper(subject);
+        assertThat(wrapper.getWrapperDelegate()).isSameAs(subject);
+        //when
+        val result = doRemoveWrapper(wrapper, wrapper);
+        //then
+        assertThat(result).isSameAs(subject);
+    }
+
+    @Test
+    public void whenWrapperToRemoveIsInvalidThenIgnoreAndReturnSelf() {
+        //given
+        val subject = createSubject();
+        val wrapper = createWrapper(subject);
+        val other = createWrapper(subject);
+        //when
+        val result = doRemoveWrapper(wrapper, other);
+        //then
+        assertThat(result).isSameAs(wrapper);
+        val resultAsWrapper = verifyIsAWrapper(result);
+        assertThat(resultAsWrapper.getWrapperDelegate()).isSameAs(subject);
+    }
+
+    @Test
+    public void whenTwoWrappersCanRemoveInner() {
+        //given
+        val subject = createSubject();
+        val inner = createWrapper(subject);
+        val outer = createWrapper(inner);
+        //when
+        val result = doRemoveWrapper(outer, inner);
+        //then
+        assertThat(result).isSameAs(outer);
+        val resultAsWrapper = verifyIsAWrapper(result);
+        assertThat(resultAsWrapper.getWrapperDelegate()).isSameAs(subject);
+    }
+
+    @Test
+    public void whenTwoInnerWrappersCanRemoveFirst() {
+        //given
+        val subject = createSubject();
+        val inner = createWrapper(subject);
+        val middle = createWrapper(inner);
+        val outer = createWrapper(middle);
+        //when
+        val result = doRemoveWrapper(outer, inner);
+        //then
+        assertThat(result).isSameAs(outer);
+        assertThat(outer.getWrapperDelegate()).isSameAs(middle);
+        assertThat(middle.getWrapperDelegate()).isSameAs(subject);
+    }
+
+    @Test
+    public void whenTwoInnerWrappersCanRemoveSecond() {
+        //given
+        val subject = createSubject();
+        val inner = createWrapper(subject);
+        val middle = createWrapper(inner);
+        val outer = createWrapper(middle);
+        //when
+        val result = doRemoveWrapper(outer, middle);
+        //then
+        assertThat(result).isSameAs(outer);
+        val resultAsWrapper = verifyIsAWrapper(result);
+        assertThat(resultAsWrapper.getWrapperDelegate()).isSameAs(inner);
+        assertThat(inner.getWrapperDelegate()).isSameAs(subject);
+    }
+
+    @Test
+    public void canRemoveOnlyWrapper() {
+        //given
+        val subject = createSubject();
+        val wrapper = createWrapper(subject);
+        //when
+        val result = doRemoveWrapper(wrapper, wrapper);
+        //then
+        assertThat(result).isSameAs(subject);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Wrapper<Subject> verifyIsAWrapper(final Subject subject) {
+        assertThat(subject).isInstanceOf(Wrapper.class);
+        return (Wrapper<Subject>) subject;
+    }
+
+    private Subject doRemoveWrapper(final Wrapper<Subject> from, final Wrapper<Subject> what) {
+        return from.removeWrapper(what);
+    }
+
+    private Wrapper<Subject> createWrapper(final Subject o) {
+        return new SubjectWrapper(o);
+    }
+
+    private Wrapper<Subject> createWrapper(final Wrapper<Subject> inner) {
+        return new SubjectWrapper(inner);
+    }
+
+    private Subject createSubject() {
+        return new Subject();
+    }
+
+    private class SubjectWrapper extends Subject implements Wrapper<Subject> {
+
+        private WrapperState<Subject> wrapperState;
+
+        SubjectWrapper(final Subject o) {
+            wrapperState = new WrapperState<>(o);
+        }
+
+        SubjectWrapper(final Wrapper<Subject> inner) {
+            wrapperState = new WrapperState<>(inner);
+        }
+
+        @Override
+        public WrapperState<Subject> getWrapperState() {
+            return this.wrapperState;
+        }
+    }
+
+    private class Subject {
+
     }
 }


### PR DESCRIPTION
* `removeWrapper()` now returns the wrapper, when it is removing itself it will return the content of the wrapper, otherwise it will return itself
* `Wrapper.asWrapper()` helper added